### PR TITLE
Output info message when PKCE without client_secret used on confident…

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -760,8 +760,8 @@ func (s *Server) handleToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if clientSecret == "" && client.Secret != "" && r.PostFormValue("code_verifier") != "" {
-		s.tokenErrHelper(w, errInvalidClient, "Missing client credentials. If you want to use PKCE without client_secret, create a public dex client.", http.StatusUnauthorized)
-		return
+		s.logger.Infof("detected PKCE token request without client_secret on client %s. "+
+			"Set the client to be pubic without client_secret, if you want to allow this.", client.ID)
 	}
 	if client.Secret != clientSecret {
 		s.tokenErrHelper(w, errInvalidClient, "Invalid client credentials.", http.StatusUnauthorized)


### PR DESCRIPTION
…ial client

* removes the special error message

Signed-off-by: Bernd Eckstein <Bernd.Eckstein@faro.com>